### PR TITLE
Adding the ability for the K2Tree to function perfectly with any value of K (k >= 2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k2_tree"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["GGabi <gabrielroels@googlemail.com>"]
 readme = "README.md"
 edition = "2018"

--- a/src/error.rs
+++ b/src/error.rs
@@ -118,6 +118,13 @@ impl std::fmt::Display for K2TreeError {
     }
   }
 }
+impl From<BitMatrixError> for K2TreeError {
+  fn from(error: BitMatrixError) -> Self {
+    K2TreeError::BitMatrixError {
+      source: Box::new(error)
+    }
+  }
+}
 
 /// Errors produced as a result of interactions with the BitMatrix object.
 #[derive(Clone, Debug)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,11 @@
 /// Errors produced as a result of interactions with the K2Tree object.
 #[derive(Clone, Debug)]
 pub enum K2TreeError {
+  /// Produced when a user attempts to create a K2Tree with a k values below 2.
+  SmallKValue {
+    ///
+    k: u8,
+  },
   /// Produced when a problem occurs attempting to traverse a K2Tree.
   /// 
   /// This mostly appears because the internal state of K2Tree is corrupted,
@@ -94,6 +99,7 @@ impl std::fmt::Display for K2TreeError {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     use K2TreeError::*;
     match self {
+      SmallKValue{k} => write!(f, "Attempt to create a K2Tree with a k value of {}, which less than the minimum of 2.", k),
       TraverseError{x, y} => write!(f, "Error encountered while traversing K2Tree for value at coordinates ({}, {})", x, y),
       OutOfBounds {
         x_y: [x, y],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,11 +74,11 @@ And then the `K2Tree` is built from this modified matrix:
 
 ```ignore
                0111
-            ____|||________
-            |    |         |
-          1101 1100      0100
-  |----|----|    |----|    |
-1000 1011 0010 1010 1000 1100
+          ______|||________
+          |     |         |
+          1101  1100      0100
+|----|----|     |----|    |
+1000 1011 0010  1010 1000 1100
 ```
 
 In the first layer of the tree, each bit refers to one of the 4 largest quadrants in the modified matrix in the order:
@@ -104,9 +104,11 @@ The final layer is referred to as the leaf-layer and contains the actual data in
 
 Finally, the above `K2Tree` is stored as a series of bits:
 
-`0111::1101,1100,0100::1000,1011,0010,1010,1000,1100`
+`[0111; 1101, 1100, 0100; 1000, 1011, 0010, 1010, 1000, 1100]`
 
-(Where `::` separates layers and `,` separates blocks)
+(Where `;` separates layers and `,` separates blocks)
+
+-- groels
 */
 
 pub use tree::K2Tree;

--- a/src/tree/datastore.rs
+++ b/src/tree/datastore.rs
@@ -747,13 +747,13 @@ impl core::fmt::Display for K2Tree {
         else { s.push('0'); }
         if i == self.k*self.k
         && (bit_pos - self.layer_start(layer_num)) < self.layer_len(layer_num)-1 {
-          s.push(',');
+          s.push_str(", ");
           i = 1;
         } 
         else { i += 1; }
       }
       i = 1;
-      s.push_str("::");
+      s.push_str("; ");
     }
     i = 1;
     for bit_pos in 0..self.leaves.len() {
@@ -761,7 +761,7 @@ impl core::fmt::Display for K2Tree {
       else { s.push('0'); }
       if i == self.k*self.k
       && bit_pos < self.leaves.len()-1 {
-        s.push(',');
+        s.push_str(", ");
         i = 1;
       } 
       else { i += 1; }
@@ -1617,5 +1617,9 @@ mod misc {
   fn is_sync() {
     fn assert_sync<T: Sync>() {}
     assert_sync::<K2Tree>();
+  }
+  #[test]
+  fn display() {
+    println!("{}", K2Tree::test_tree(3));
   }
 }

--- a/src/tree/iterators.rs
+++ b/src/tree/iterators.rs
@@ -45,6 +45,7 @@ pub struct Stems<'a> {
 impl<'a> Iterator for Stems<'a> {
   type Item = StemBit;
   fn next(&mut self) -> Option<Self::Item> {
+    let block_len = self.tree.block_len();
     if self.pos >= self.tree.stems.len() {
       return None
     }
@@ -57,9 +58,9 @@ impl<'a> Iterator for Stems<'a> {
     });
     /* Increment the iterator's state for next value */
     self.pos += 1;
-    if self.bit == 3 {
+    if self.bit == block_len-1 {
       self.bit = 0;
-      if self.stem == (self.tree.layer_len(self.layer)/4)-1 {
+      if self.stem == (self.tree.layer_len(self.layer) / block_len) - 1 {
         self.stem = 0;
         self.layer += 1;
       }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -92,6 +92,41 @@ impl K2Tree {
   }
 }
 
+/* Block Utils */
+impl K2Tree {
+  fn block_len(&self) -> usize {
+    self.k.pow(2)
+  }
+  fn block_start(&self, bit_pos: usize) -> usize {
+    (bit_pos / self.block_len()) * self.block_len()
+  }
+  fn remove_block(&mut self, bv: &mut BitVec, block_start: usize) -> std::result::Result<(), ()> {
+    let block_len = self.block_len();
+    if block_start > (bv.len() - block_len)
+    || block_start % block_len != 0 {
+      Err(())
+    }
+    else {
+      for _ in 0..block_len { bv.remove(block_start); }
+      Ok(())
+    }
+  }
+  fn insert_block(&mut self, bv: &mut BitVec, block_start: usize) -> std::result::Result<(), ()> {
+    let block_len = self.block_len();
+    if block_start > bv.len()
+    || block_start % block_len != 0 {
+      Err(())
+    }
+    else {
+      for _ in 0..block_len { bv.insert(block_start, false); }
+      Ok(())
+    }
+  }
+  fn to_subranges(&self, r: Range2D) -> std::result::Result<SubRanges, ()> {
+    SubRanges::from_range(r, self.k, self.k)
+  }
+}
+
 const fn block_start(bit_pos: usize) -> usize {
   (bit_pos / 4) * 4
 }
@@ -147,4 +182,145 @@ fn one_positions_range(bits: &BitVec, begin: usize, end: usize) -> Vec<usize> {
   bits[begin..end].into_iter().enumerate().filter_map(|(pos, bit)|
     if *bit { Some(pos) } else { None }
   ).collect()
+}
+
+/* Ranges */
+#[derive(Debug, Clone)]
+struct SubRanges {
+  /// Number of horizontal subranges.
+  width: usize,
+  /// Number of vertical subranges.
+  height: usize,
+  /// Subranges
+  subranges: Vec<Range2D>,
+}
+impl SubRanges {
+  fn from_range(r: Range2D, w: usize, h: usize) -> std::result::Result<Self, ()> {
+    // If the range cannot be evenly divided up by w and h, break
+    if r.width() / w * w != r.width()
+    || r.height() / h * h != r.height() {
+      return Err(())
+    }
+    let mut subranges: Vec<Range2D> = Vec::new();
+    let sub_width = r.width() / w;
+    let sub_height = r.height() / h;
+    // Process subranges by rows then columns
+    for y in 0..h {
+      for x in 0..w {
+        let min_x = r.min_x + (x * sub_width);
+        let max_x = min_x + sub_width-1;
+        let min_y = r.min_y + (y * sub_height);
+        let max_y = min_y + sub_height-1;
+        subranges.push(Range2D::new(min_x, max_x, min_y, max_y));
+      }
+    }
+    Ok(SubRanges {
+      width: w,
+      height: h,
+      subranges
+    })
+  }
+  fn get(&self, x: usize, y: usize) -> Range2D {
+    let index: usize = (y * self.width) + x;
+    self.subranges[index].clone()
+  }
+}
+
+#[derive(Debug, Clone)]
+struct Range2D {
+  pub min_x: usize,
+  pub max_x: usize,
+  pub min_y: usize,
+  pub max_y: usize
+}
+impl Range2D {
+  fn new(min_x: usize, max_x: usize, min_y: usize, max_y: usize) -> Self {
+    Range2D {
+      min_x,
+      max_x,
+      min_y,
+      max_y
+    }
+  }
+  fn from_range(r: Range) -> Self {
+    Range2D {
+      min_x: r[0][0],
+      max_x: r[0][1],
+      min_y: r[1][0],
+      max_y: r[1][1],
+    }
+  }
+  fn width(&self) -> usize {
+    self.max_x - self.min_x + 1 // +1 because range is inclusive
+  }
+  fn height(&self) -> usize {
+    self.max_y - self.min_y + 1 // +1 because range is inclusive
+  }
+  fn contains(&self, x: usize, y: usize) -> bool {
+    x >= self.min_x && x <= self.max_x
+    && y >= self.min_y && y <= self.max_y
+  }
+  fn to_range(&self) -> Range {
+    [[self.min_x, self.max_x], [self.min_y, self.max_y]]
+  }
+}
+
+/* Tests */
+#[cfg(tests)]
+mod range_tests {
+  use super::*;
+  #[test]
+  fn range2d_from_range() {
+    let range = [[0, 7], [0, 7]];
+    let expected = Range2D {
+      min_x: 0,
+      max_x: 7,
+      min_y: 0,
+      max_y: 7,
+    };
+    assert_eq!(expected, Range2D::from_range(range));
+  }
+  #[test]
+  fn subranges_from_range2d_0() {
+    let original = Range2D::new(0, 7, 0, 7);
+    let expected_subs = [
+      Range2D::new(0, 3, 0, 3),
+      Range2D::new(4, 7, 0, 3),
+      Range2D::new(0, 3, 4, 7),
+      Range2D::new(4, 7, 4, 7),
+    ];
+    let subs = SubRange::from_range(original, 2, 2);
+    for i in 0..4 { assert_eq!(expected_subs[i], subs.subranges[i]); }
+  }
+  #[test]
+  fn subranges_from_range2d_1() {
+    let original = Range2D::new(0, 8, 0, 8);
+    let expected_subs = [
+      Range2D::new(0, 2, 0, 2),
+      Range2D::new(3, 5, 0, 2),
+      Range2D::new(6, 8, 0, 2),
+      Range2D::new(0, 2, 3, 5),
+      Range2D::new(3, 5, 3, 5),
+      Range2D::new(6, 8, 3, 5),
+      Range2D::new(0, 2, 6, 8),
+      Range2D::new(3, 5, 6, 8),
+      Range2D::new(6, 8, 6, 8),
+    ];
+    let subs = SubRange::from_range(original, 3, 3);
+    for i in 0..9 { assert_eq!(expected_subs[i], subs.subranges[i]); }
+  }
+  #[test]
+  fn subranges_from_range2d_2() {
+    let original = Range2D::new(0, 8, 0, 7);
+    let expected_subs = [
+      Range2D::new(0, 2, 0, 3),
+      Range2D::new(3, 5, 0, 3),
+      Range2D::new(6, 8, 0, 3),
+      Range2D::new(0, 2, 4, 7),
+      Range2D::new(3, 5, 4, 7),
+      Range2D::new(6, 8, 4, 7),
+    ];
+    let subs = SubRange::from_range(original, 3, 2);
+    for i in 0..6 { assert_eq!(expected_subs[i], subs.subranges[i]); }
+  }
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -136,20 +136,20 @@ fn ones_in_range(bits: &BitVec, begin: usize, end: usize) -> usize {
 fn all_zeroes(bits: &BitVec, begin: usize, end: usize) -> bool {
   bits[begin..end].into_iter().fold(true, |total, bit| total & !bit)
 }
-#[allow(dead_code)] //very may well need this later
-fn one_positions(bits: &BitVec) -> Vec<usize> {
+fn one_positions(bits: impl Iterator<Item=bool>) -> Vec<usize> {
   bits
-  .iter()
   .enumerate()
   .filter_map(
     |(pos, bit)|
-    if *bit { Some(pos) }
+    if bit { Some(pos) }
     else   { None })
   .collect()
 }
 fn one_positions_range(bits: &BitVec, begin: usize, end: usize) -> Vec<usize> {
-  bits[begin..end].into_iter().enumerate().filter_map(|(pos, bit)|
-    if *bit { Some(pos) } else { None }
+  bits[begin..end].into_iter().enumerate()
+  .filter_map(|(pos, bit)|
+    if *bit { Some(pos) }
+    else    { None }
   ).collect()
 }
 


### PR DESCRIPTION
This update adds new methods:
 - `K2Tree::with_k(k: usize)`
 - `K2Tree.set_k(&mut self, k: usize)`

Which together allow users to create, and work with, K2Trees with values of k other than the previously fixed 2.
Various other changes were made to the library, including the new public BitMatrix object and the addition of extra "k" parameters to methods that now need to take into account a custom value for k e.g. `K2Tree::from_matrix(matrix: BitMatrix, k: usize)`.

Other quality of life improvements such as better Range objects which allow for easier development moving forward.

