### PR TITLE
Separating the K field into `stem_k` and `leaf_k`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k2_tree"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["GGabi <gabrielroels@googlemail.com>"]
 readme = "README.md"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See the original proposal [here](https://users.dcc.uchile.cl/~gnavarro/ps/spire0
 Add  `k2_tree`  into your project dependencies:
 ```none
 [dependencies]
-k2_tree = "0.3.2"
+k2_tree = "0.4.0"
 ```
 # When `K2Tree`s are Useful:
 `K2Tree`s are extremely efficient at representing data that can be encoded as a two-dimensional bit-matrix, especially if said matrix is sparsely populated.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Another example is representing Triple-Stores, which [this repo](https://github.
 ```rust
 K2Tree {
   matrix_width: 8,
-  k: 2,
+  stem_k: 2,
+  leaf_k: 2,
   max_slayers: 2,
   slayer_starts: [0, 4],
   stems: [0111110111000100],
@@ -54,7 +55,7 @@ K2Tree {
 For a more in-depth explenation of the explanation process, [check this out](HOWITWORKS.md).
 # The Road to 1.0:
 - [x] Make `K2Tree` work over any value of K.
-- [ ]  Separate the `k` field into two distinct fields: `stem_k`, `leaf_k`.
+- [x]  Separate the `k` field into two distinct fields: `stem_k`, `leaf_k`.
 - [ ]  Attempt to increase compression ratio by removing the `stem_to_leaf` field without compromising operation complexity.
 - [ ] Unit test all the things.
 - [ ] Stabilise the API.

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,9 +17,14 @@ while minimising the number of unique enumerations required:
 #[derive(Clone, Debug)]
 pub enum K2TreeError {
   /// Produced when a user attempts to create a K2Tree with a k values below 2.
-  SmallKValue {
+  SmallStemKValue {
     ///
-    k: u8,
+    stem_k: u8,
+  },
+  /// Produced when a user attempts to create a K2Tree with a k values below 2.
+  SmallLeafKValue {
+    ///
+    leaf_k: u8,
   },
   /// Produced when a problem occurs attempting to traverse a K2Tree.
   /// 
@@ -120,7 +125,8 @@ impl std::fmt::Display for K2TreeError {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     use K2TreeError::*;
     match self {
-      SmallKValue{k} => write!(f, "Attempt to create a K2Tree with a k value of {}, which less than the minimum of 2.", k),
+      SmallStemKValue{stem_k} => write!(f, "Attempt to create a K2Tree with a stem_k value of {}, which less than the minimum of 2.", stem_k),
+      SmallLeafKValue{leaf_k} => write!(f, "Attempt to create a K2Tree with a leaf_k value of {}, which less than the minimum of 2.", leaf_k),
       TraverseError{x, y} => write!(f, "Error encountered while traversing K2Tree for value at coordinates ({}, {})", x, y),
       OutOfBounds {
         x_y: [x, y],

--- a/src/tree/datastore.rs
+++ b/src/tree/datastore.rs
@@ -18,7 +18,7 @@ type Result<T> = std::result::Result<T, Error>;
 /// fn main() -> Result<(), k2_tree::error::K2TreeError> {
 ///   use k2_tree::K2Tree;
 ///   //matrix_width = 8, k = 2
-///   let mut tree = K2Tree::with_k(2)?;
+///   let mut tree = K2Tree::with_k(2, 2)?;
 ///   tree.set(0, 4, true);
 ///   tree.set(6, 5, true);
 ///   tree.set(0, 4, false);
@@ -34,7 +34,8 @@ pub struct K2Tree {
   /// so this is also the height.
   pub matrix_width: usize,
   /// The k value of the K2Tree, currently fixed at 2.
-  pub k: usize, //TODO: separate stem_k from leaf_k
+  pub stem_k: usize,
+  pub leaf_k: usize,
   /// The maximum number of stem-layers possible given the matrix_width.
   pub max_slayers: usize,
   /// The index of the first bit in each stem-layer in stems.
@@ -60,12 +61,13 @@ impl K2Tree {
   /// let tree = K2Tree::new();
   /// assert!(tree.is_empty());
   /// assert_eq!(8, tree.matrix_width);
-  /// assert_eq!(2, tree.k);
+  /// assert_eq!(2, tree.stem_k); //TODO
   /// ```
   pub fn new() -> Self {
     K2Tree {
       matrix_width: 8,
-      k: 2,
+      stem_k: 2,
+      leaf_k: 2,
       max_slayers: 2,
       slayer_starts: vec![0],
       stems: bitvec![0; 4],
@@ -79,26 +81,27 @@ impl K2Tree {
   /// ```
   /// fn main() -> Result<(), k2_tree::error::K2TreeError> {
   ///   use k2_tree::K2Tree;
-  ///   let tree = K2Tree::with_k(4)?;
+  ///   let tree = K2Tree::with_k(4, 4)?;
   ///   assert!(tree.is_empty());
   ///   assert_eq!(4usize.pow(3), tree.matrix_width);
   ///   assert_eq!(64, tree.matrix_width);
-  ///   assert_eq!(4, tree.k);
+  ///   assert_eq!(4, tree.stem_k); //TODO
   ///   Ok(())
   /// }
   /// ``` 
-  pub fn with_k(k: usize) -> Result<Self> {
-    if k < 2 {
-      return Err(Error::SmallKValue { k: k as u8 })
+  pub fn with_k(stem_k: usize, leaf_k: usize) -> Result<Self> {
+    if stem_k < 2 || leaf_k < 2 {
+      return Err(Error::SmallKValue { k: stem_k as u8 }) //TODO: proper error
     }
     /* For now fix k as 2, further work to make it user-defined */
-    let mw = k.pow(3);
+    let mw = leaf_k * stem_k.pow(2);
     Ok(K2Tree {
       matrix_width: mw,
-      k,
-      max_slayers: (mw as f64).log(k as f64) as usize - 1,
+      stem_k,
+      leaf_k,
+      max_slayers: (mw as f64).log(stem_k as f64) as usize - 1,
       slayer_starts: vec![0],
-      stems: bitvec![0; k*k],
+      stems: bitvec![0; stem_k*stem_k],
       stem_to_leaf: Vec::new(),
       leaves: BitVec::new(),
     })
@@ -115,8 +118,8 @@ impl K2Tree {
   ///   Ok(())
   /// }
   /// ``` 
-  pub fn set_k(&mut self, k: usize) -> Result<()> {
-    if self.k == k { return Ok(()) }
+  pub fn set_k(&mut self, k: usize) -> Result<()> { //TODO: Split into leaf and stem
+    if self.leaf_k == k { return Ok(()) }
     if k < 2 {
       return Err(Error::SmallKValue{k: k as u8})
     }
@@ -132,7 +135,7 @@ impl K2Tree {
   /// ```
   /// fn main() -> Result<(), k2_tree::error::K2TreeError> {
   ///   use k2_tree::K2Tree;
-  ///   let mut tree = K2Tree::with_k(2)?;
+  ///   let mut tree = K2Tree::with_k(2, 2)?;
   ///   tree.set(0, 1, true)?;
   ///   assert_eq!(true, tree.get(0, 1)?);
   ///   assert_eq!(false, tree.get(0, 0)?);
@@ -157,8 +160,8 @@ impl K2Tree {
     };
     match descend_result {
       DescendResult::Leaf(leaf_start, leaf_range) => {
-        if leaf_range.width() != self.k
-        || leaf_range.height() != self.k {
+        if leaf_range.width() != self.leaf_k
+        || leaf_range.height() != self.leaf_k {
           return Err(Error::Read {
             source: Box::new(Error::TraverseError{x, y})
           })
@@ -166,7 +169,7 @@ impl K2Tree {
         //Calculation removes extra branches, makes it faster
         // range = [[5, 6], [7, 8]]
         // (5, 7) = 0; (6, 7) = 1; (5, 8) = 2; (6, 8) = 3
-        let offset = (self.k * (y - leaf_range.min_y)) + (x - leaf_range.min_x);
+        let offset = (self.leaf_k * (y - leaf_range.min_y)) + (x - leaf_range.min_x); //TODO: check
         Ok(self.leaves[leaf_start+offset])
       },
       DescendResult::Stem(_, _) => Ok(false),
@@ -177,7 +180,7 @@ impl K2Tree {
   /// fn main() -> Result<(), k2_tree::error::K2TreeError> {
   ///   use bitvec::prelude::bitvec;
   ///   use k2_tree::K2Tree;
-  ///   let mut tree = K2Tree::with_k(2)?;
+  ///   let mut tree = K2Tree::with_k(2, 2)?;
   ///   tree.set(1, 0, true)?;
   ///   tree.set(3, 0, true)?;
   ///   tree.set(6, 0, true)?;
@@ -199,7 +202,7 @@ impl K2Tree {
       })
     }
     let mut ret_v = Vec::new();
-    for x in (0..self.matrix_width).step_by(self.k) {
+    for x in (0..self.matrix_width).step_by(self.stem_k) { //TODO
       let descend_result = match self.matrix_bit(x, y, self.matrix_width) {
         Ok(dr) => dr,
         Err(e) => return Err(Error::Read {
@@ -208,18 +211,18 @@ impl K2Tree {
       };
       match descend_result {
         DescendResult::Leaf(leaf_start, leaf_range) => {
-          if leaf_range.width() != self.k
-          || leaf_range.height() != self.k {
+          if leaf_range.width() != self.leaf_k
+          || leaf_range.height() != self.leaf_k {
             return Err(Error::Read {
               source: Box::new(Error::TraverseError{x, y})
             })
           }
           //Calculation instead of if-else block makes hot-code much faster
-          let offset = (self.k * (y - leaf_range.min_y)) + (x - leaf_range.min_x);
-          for i in 0..self.k { ret_v.push(self.leaves[leaf_start+offset+i]); }
+          let offset = (self.leaf_k * (y - leaf_range.min_y)) + (x - leaf_range.min_x);
+          for i in 0..self.leaf_k { ret_v.push(self.leaves[leaf_start+offset+i]); } //TODO: check
         },
         DescendResult::Stem(_, _) => {
-          for _ in 0..self.k { ret_v.push(false); }
+          for _ in 0..self.leaf_k { ret_v.push(false); }
         },
       }
     };
@@ -230,7 +233,7 @@ impl K2Tree {
   /// fn main() -> Result<(), k2_tree::error::K2TreeError> {
   ///   use bitvec::prelude::bitvec;
   ///   use k2_tree::K2Tree;
-  ///   let mut tree = K2Tree::with_k(2)?;
+  ///   let mut tree = K2Tree::with_k(2, 2)?;
   ///   tree.set(1, 1, true)?;
   ///   tree.set(1, 3, true)?;
   ///   tree.set(1, 6, true)?;
@@ -252,7 +255,7 @@ impl K2Tree {
       })
     }
     let mut ret_v = Vec::new();
-    for y in (0..self.matrix_width).step_by(self.k) {
+    for y in (0..self.matrix_width).step_by(self.stem_k) { //TODO
       let descend_result = match self.matrix_bit(x, y, self.matrix_width) {
         Ok(dr) => dr,
         Err(e) => return Err(Error::Read {
@@ -261,17 +264,17 @@ impl K2Tree {
       };
       match descend_result{
         DescendResult::Leaf(leaf_start, leaf_range) => {
-          if leaf_range.width() != self.k
-          || leaf_range.height() != self.k {
+          if leaf_range.width() != self.leaf_k
+          || leaf_range.height() != self.leaf_k {
             return Err(Error::Read {
               source: Box::new(Error::TraverseError{x, y})
             })
           }
-          let offset = (self.k * (y - leaf_range.min_y)) + (x - leaf_range.min_x);
-          for i in 0..self.k { ret_v.push(self.leaves[leaf_start+offset+(i*self.k)]); }
+          let offset = (self.leaf_k * (y - leaf_range.min_y)) + (x - leaf_range.min_x); //TODO: check
+          for i in 0..self.leaf_k { ret_v.push(self.leaves[leaf_start+offset+(i*self.leaf_k)]); } //TODO: check
         },
         DescendResult::Stem(_, _) => {
-          for _ in 0..self.k { ret_v.push(false); }
+          for _ in 0..self.leaf_k { ret_v.push(false); }
         },
       }
     };
@@ -282,7 +285,7 @@ impl K2Tree {
   /// ```
   /// fn main() -> Result<(), k2_tree::error::K2TreeError> {
   ///   use k2_tree::K2Tree;
-  ///   let mut tree = K2Tree::with_k(2)?;
+  ///   let mut tree = K2Tree::with_k(2, 2)?;
   ///   assert_eq!(false, tree.get(0, 0)?);
   ///   tree.set(0, 0, true)?;
   ///   assert_eq!(true, tree.get(0, 0)?);
@@ -290,7 +293,7 @@ impl K2Tree {
   /// }
   /// ```
   pub fn set(&mut self, x: usize, y: usize, state: bool) -> Result<()> {
-    let block_len = self.block_len();
+    let block_len = self.stem_len(); //TODO: this is defo wrong
     let descend_result = match self.matrix_bit(x, y, self.matrix_width) {
       Ok(dr) => dr,
       Err(e) => return Err(Error::Write {
@@ -299,15 +302,15 @@ impl K2Tree {
     };
     match descend_result {
       DescendResult::Leaf(leaf_start, leaf_range) => {
-        if leaf_range.width() != self.k
-        || leaf_range.height() != self.k {
+        if leaf_range.width() != self.leaf_k
+        || leaf_range.height() != self.leaf_k {
           /* Final submatrix isn't a k by k so can't be a leaf */
           return Err(Error::Write {
             source: Box::new(Error::TraverseError{x, y})
           })
         }
         /* Set the bit in the leaf to the new state */
-        let offset = (self.k * (y - leaf_range.min_y)) + (x - leaf_range.min_x);
+        let offset = (self.leaf_k * (y - leaf_range.min_y)) + (x - leaf_range.min_x); //TODO: check
         self.leaves.set(leaf_start+offset, state);
         /* If leaf is now all 0's, remove leaf and alter rest of struct to reflect changes.
         Loop up the stems changing the parent bits to 0's and removing stems that become all 0's */
@@ -344,7 +347,7 @@ impl K2Tree {
           let layer_start = self.slayer_starts[self.max_slayers-1];
           self.stems.set(layer_start + stem_bit_pos, false); //Dead leaf parent bit = 0
           let mut curr_layer = self.max_slayers-1;
-          let mut stem_start = layer_start + self.block_start(stem_bit_pos);
+          let mut stem_start = layer_start + self.stem_start(stem_bit_pos);
           dbg!(stem_start, layer_start, &self.stems);
           while curr_layer > 0
           && all_zeroes(&self.stems, stem_start, stem_start+block_len) {
@@ -445,7 +448,7 @@ impl K2Tree {
               source: Box::new(Error::Write {
                 source: Box::new(Error::StemInsertionError {
                   pos: stem_start,
-                  len: self.block_len()
+                  len: block_len
                 })
               })
             })
@@ -525,7 +528,7 @@ impl K2Tree {
         }
         /* Change bit at (x, y) to 1 */
         let leaf_range = subrange;
-        let offset = (self.k * (y - leaf_range.min_y)) + (x - leaf_range.min_x);
+        let offset = (self.leaf_k * (y - leaf_range.min_y)) + (x - leaf_range.min_x); //TODO: check
         self.leaves.set(leaf_start+offset, true);
         return Ok(())
       }
@@ -571,8 +574,8 @@ impl K2Tree {
   /// ```
   /// fn main() -> Result<(), k2_tree::error::K2TreeError> {
   ///   use k2_tree::K2Tree;
-  ///   let mut tree = K2Tree::with_k(2)?;
-  ///   assert_eq!(2, tree.k);
+  ///   let mut tree = K2Tree::with_k(2, 2)?;
+  ///   assert_eq!(2, tree.stem_k); //TODO
   ///   assert_eq!(8, tree.matrix_width);
   ///   tree.grow();
   ///   assert_eq!(16, tree.matrix_width);
@@ -582,8 +585,8 @@ impl K2Tree {
   /// }
   /// ```
   pub fn grow(&mut self) {
-    let block_len = self.block_len();
-    self.matrix_width *= self.k;
+    let block_len = self.stem_len();
+    self.matrix_width *= self.stem_k; //TODO: check
     self.max_slayers += 1;
     if self.leaves.len() > 0  {
       /* Only insert the extra layers etc. if the
@@ -604,7 +607,7 @@ impl K2Tree {
   /// ```
   /// fn main() -> Result<(), k2_tree::error::K2TreeError> {
   ///   use k2_tree::K2Tree;
-  ///   let mut tree = K2Tree::with_k(2)?;
+  ///   let mut tree = K2Tree::with_k(2, 2)?;
   ///   tree.grow();
   ///   assert_eq!(16, tree.matrix_width);
   ///   tree.shrink_if_possible();
@@ -625,7 +628,7 @@ impl K2Tree {
   /// ```
   /// fn main() -> Result<(), k2_tree::error::K2TreeError> {
   ///   use k2_tree::K2Tree;
-  ///   let mut tree = K2Tree::with_k(2)?;
+  ///   let mut tree = K2Tree::with_k(2, 2)?;
   ///   tree.grow();
   ///   assert_eq!(16, tree.matrix_width);
   ///   assert!(tree.shrink().is_ok());
@@ -635,8 +638,8 @@ impl K2Tree {
   /// }
   /// ```
   pub fn shrink(&mut self) -> Result<()> {
-    let block_len = self.block_len();
-    if self.matrix_width <= self.k.pow(3) {
+    let block_len = self.stem_len(); //TODO: check
+    if self.matrix_width <= self.leaf_k * self.stem_k.pow(2) { //TDOD: check
       return Err(Error::CouldNotShrink {
         reason: format!("Already at minimum size: {}", self.matrix_width)
       })
@@ -646,7 +649,7 @@ impl K2Tree {
         reason: "Shrinking would lose information about the matrix".into()
       })
     }
-    self.matrix_width /= self.k;
+    self.matrix_width /= self.stem_k; //TODO: check
     self.max_slayers -= 1;
     self.slayer_starts.remove(0);
     for slayer_start in &mut self.slayer_starts {
@@ -665,7 +668,7 @@ impl K2Tree {
   /// ```
   /// fn main() -> Result<(), k2_tree::error::K2TreeError> {
   ///   use k2_tree::K2Tree;
-  ///   let mut tree = K2Tree::with_k(2)?;
+  ///   let mut tree = K2Tree::with_k(2, 2)?;
   ///   tree.grow();
   ///   assert_eq!(16, tree.matrix_width);
   ///   unsafe { tree.shrink_unchecked(); }
@@ -674,8 +677,8 @@ impl K2Tree {
   /// }
   /// ```
   pub unsafe fn shrink_unchecked(&mut self) {
-    let block_len = self.block_len();
-    self.matrix_width /= self.k;
+    let block_len = self.stem_len(); //TODO: check
+    self.matrix_width /= self.stem_k; //TODO: check
     self.max_slayers -= 1;
     self.slayer_starts.remove(0);
     for slayer_start in &mut self.slayer_starts {
@@ -690,7 +693,7 @@ impl K2Tree {
   /// ```
   /// fn main() -> Result<(), k2_tree::error::K2TreeError> {
   ///   use k2_tree::K2Tree;
-  ///   let mut tree = K2Tree::with_k(2)?;
+  ///   let mut tree = K2Tree::with_k(2, 2)?;
   ///   tree.set(0, 0, true)?;
   ///   tree.set(5, 6, true)?;
   ///   tree.set(7, 7, true)?;
@@ -721,7 +724,7 @@ impl K2Tree {
   /// ```
   /// fn main() -> Result<(), k2_tree::error::K2TreeError> {
   ///   use k2_tree::K2Tree;
-  ///   let mut tree = K2Tree::with_k(2)?;
+  ///   let mut tree = K2Tree::with_k(2, 2)?;
   ///   tree.set(0, 0, true)?;
   ///   tree.set(5, 6, true)?;
   ///   tree.set(7, 7, true)?;
@@ -756,7 +759,7 @@ impl K2Tree {
   /// assert!(K2Tree::from_matrix(m, 2).is_ok());
   /// ```
   pub fn from_matrix(matrix: BitMatrix, k: usize) -> Result<Self> {
-    let mut tree = K2Tree::with_k(k)?;
+    let mut tree = K2Tree::with_k(k, k)?;
     while matrix.width > tree.matrix_width
     || matrix.height > tree.matrix_width {
       tree.grow();
@@ -782,7 +785,7 @@ impl core::fmt::Display for K2Tree {
       for bit_pos in self.layer_start(layer_num)..self.layer_start(layer_num+1) {
         if self.stems[bit_pos] { s.push('1'); }
         else { s.push('0'); }
-        if i == self.k*self.k
+        if i == self.stem_k*self.stem_k
         && (bit_pos - self.layer_start(layer_num)) < self.layer_len(layer_num)-1 {
           s.push_str(", ");
           i = 1;
@@ -796,7 +799,7 @@ impl core::fmt::Display for K2Tree {
     for bit_pos in 0..self.leaves.len() {
       if self.leaves[bit_pos] { s.push('1'); }
       else { s.push('0'); }
-      if i == self.k*self.k
+      if i == self.leaf_k*self.leaf_k
       && bit_pos < self.leaves.len()-1 {
         s.push_str(", ");
         i = 1;
@@ -808,7 +811,8 @@ impl core::fmt::Display for K2Tree {
 }
 impl PartialEq for K2Tree {
   fn eq(&self, other: &Self) -> bool {
-    self.k == other.k
+    self.stem_k == other.stem_k
+    && self.leaf_k == other.leaf_k
     && self.matrix_width == other.matrix_width
     && self.stems == other.stems
     && self.leaves == other.leaves
@@ -822,7 +826,8 @@ impl Default for K2Tree {
 }
 impl std::hash::Hash for K2Tree {
   fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.k.hash(state);
+    self.stem_k.hash(state);
+    self.leaf_k.hash(state);
     self.matrix_width.hash(state);
     self.stems.hash(state);
     self.leaves.hash(state);
@@ -841,9 +846,9 @@ struct DescendEnv {
   slayer_max: usize,
 }
 impl K2Tree {
-  fn layer_from_range(&self, r: Range2D) -> usize {
-    ((self.matrix_width as f64).log(self.k as f64) as usize)
-    - ((r.width() as f64).log(self.k as f64) as usize)
+  fn layer_from_range(&self, r: Range2D) -> usize { //TODO: Check stem_k cool
+    ((self.matrix_width as f64).log(self.stem_k as f64) as usize)
+    - ((r.width() as f64).log(self.stem_k as f64) as usize)
   }
   fn matrix_bit(&self, x: usize, y: usize, m_width: usize) -> Result<DescendResult> {
     let env = DescendEnv {
@@ -855,11 +860,11 @@ impl K2Tree {
   }
   fn descend(&self, env: &DescendEnv, layer: usize, stem_pos: usize, range: Range2D) -> Result<DescendResult> {
     let subranges = self.to_subranges(range)?;
-    for (child_pos, child) in self.stems[stem_pos..stem_pos+self.block_len()].iter().enumerate() {
+    for (child_pos, child) in self.stems[stem_pos..stem_pos+self.stem_len()].iter().enumerate() { //TODO: check
       if subranges[child_pos].contains(env.x, env.y) {
         if !child { return Ok(DescendResult::Stem(stem_pos, range)) } //The bit exists within a range that has all zeros
         else if layer == env.slayer_max {
-          let leaf_start = match self.leaf_start(stem_pos + child_pos) {
+          let leaf_start = match self.stem_to_leaf_start(stem_pos + child_pos) {
             Ok(ls) => ls,
             Err(_) => return Err(Error::TraverseError {
               x: env.x,
@@ -888,12 +893,12 @@ impl K2Tree {
   fn num_stems_before_child(&self, bit_pos: usize, layer: usize) -> usize {
     ones_in_range(&self.stems, self.layer_start(layer), bit_pos)
   }
-  fn leaf_start(&self, stem_bitpos: usize) -> std::result::Result<usize, ()> {
+  fn stem_to_leaf_start(&self, stem_bitpos: usize) -> std::result::Result<usize, ()> {
     if !self.stems[stem_bitpos] { return Err(()) }
     if let Some(leaf_num) = self.stem_to_leaf.iter().position(|&n|
       n == (stem_bitpos - self.slayer_starts[self.max_slayers-1])
     ) {
-      return Ok(leaf_num * self.block_len())
+      return Ok(leaf_num * self.stem_len()) //TODO: check
     }
     Err(())
   }
@@ -904,7 +909,7 @@ impl K2Tree {
       return Err(())
     }
     Ok(self.layer_start(layer+1)
-    + (self.num_stems_before_child(stem_start+nth_child, layer) * self.block_len()))
+    + (self.num_stems_before_child(stem_start+nth_child, layer) * self.stem_len())) //TODO: check
   }
 }
 
@@ -915,7 +920,8 @@ impl K2Tree {
     match k {
       2 => K2Tree {
         matrix_width: 8,
-        k: 2,
+        stem_k: 2,
+        leaf_k: 2,
         max_slayers: 2,
         slayer_starts: vec![0, 4],
         stems:  bitvec![0,1,1,1, 1,1,0,1, 1,0,0,0, 1,0,0,0],
@@ -924,7 +930,8 @@ impl K2Tree {
       },
       3 => K2Tree {
         matrix_width: 27,
-        k: 3,
+        stem_k: 3,
+        leaf_k: 3,
         max_slayers: 2,
         slayer_starts: vec![0, 9],
         stems:  bitvec![
@@ -939,7 +946,8 @@ impl K2Tree {
       },
       4 => K2Tree {
         matrix_width: 64,
-        k: 4,
+        stem_k: 4,
+        leaf_k: 4,
         max_slayers: 2,
         slayer_starts: vec![0, 16],
         stems: bitvec![
@@ -956,7 +964,7 @@ impl K2Tree {
           0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,
         ],
       },
-      _ => K2Tree::with_k(2).unwrap(),
+      _ => K2Tree::with_k(2, 2).unwrap(),
     }
   }
   fn test_matrix(k: usize) -> BitMatrix {
@@ -1043,7 +1051,8 @@ mod api {
   fn new() {
     let expected = K2Tree {
       matrix_width: 8,
-      k: 2,
+      stem_k: 2,
+      leaf_k: 2,
       max_slayers: 2,
       slayer_starts: vec![0],
       stems: bitvec![0,0,0,0],
@@ -1054,7 +1063,7 @@ mod api {
   }
   #[test]
   fn with_k_0() -> Result<()> {
-    assert_eq!(K2Tree::with_k(2)?, K2Tree::new());
+    assert_eq!(K2Tree::with_k(2, 2)?, K2Tree::new());
     Ok(())
   }
   #[test]
@@ -1062,14 +1071,15 @@ mod api {
     for k in 2..9usize {
       let expected = K2Tree {
         matrix_width: k.pow(3),
-        k,
+        stem_k: k,
+        leaf_k: k,
         max_slayers: 2,
         slayer_starts: vec![0],
         stems: bitvec![0; k.pow(2)],
         stem_to_leaf: Vec::new(),
         leaves: BitVec::new(),
       };
-      assert_eq!(K2Tree::with_k(k)?, expected);
+      assert_eq!(K2Tree::with_k(k, k)?, expected);
     }
     Ok(())
   }
@@ -1089,7 +1099,8 @@ mod api {
     assert!(tree.set_k(3).is_ok());
     let expected = K2Tree {
       matrix_width: 27,
-      k: 3,
+      stem_k: 3,
+      leaf_k: 3,
       max_slayers: 2,
       slayer_starts: vec![0, 9],
       stems: bitvec![1,0,0,0,0,0,0,0,0, 0,1,1,1,1,0,0,0,0],
@@ -1107,7 +1118,8 @@ mod api {
     assert!(tree.set_k(2).is_ok());
     let expected = K2Tree {
       matrix_width: 32,
-      k: 2,
+      stem_k: 2,
+      leaf_k: 2,
       max_slayers: 4,
       slayer_starts: vec![0, 4, 12, 32],
       stems: bitvec![
@@ -1125,14 +1137,14 @@ mod api {
   #[test]
   fn is_empty_0() -> Result<()> {
     for i in 2..10 {
-      let tree = K2Tree::with_k(i)?;
+      let tree = K2Tree::with_k(i, i)?;
       assert!(tree.is_empty());
     }
     Ok(())
   }
   #[test]
   fn is_empty_1() -> Result<()> {
-    let mut tree = K2Tree::with_k(2)?;
+    let mut tree = K2Tree::with_k(2, 2)?;
     tree.set(0, 0, true)?;
     assert!(!tree.is_empty());
     tree.set(0, 0, false)?;
@@ -1199,7 +1211,7 @@ mod api {
   }
   #[test]
   fn set_0() -> Result<()> {
-    let mut tree = K2Tree::with_k(2)?;
+    let mut tree = K2Tree::with_k(2, 2)?;
     assert_eq!(false, tree.get(0, 0).unwrap());
     tree.set(0, 0, true)?;
     assert_eq!(true, tree.get(0, 0).unwrap());
@@ -1220,7 +1232,7 @@ mod api {
   }
   #[test]
   fn set_1() -> Result<()> {
-    let mut tree = K2Tree::with_k(2)?;
+    let mut tree = K2Tree::with_k(2, 2)?;
     tree.grow();
     for i in 0..256 {
       let [x, y] = [i%16, i/16];
@@ -1234,7 +1246,7 @@ mod api {
   #[test]
   fn set_2() -> Result<()> {
     for k in 2..5 {
-      let mut tree = K2Tree::with_k(k)?;
+      let mut tree = K2Tree::with_k(k, k)?;
       for y in 0..(k.pow(3)) {
         for x in 0..(k.pow(3)) {
           assert_eq!(false, tree.get(x, y)?);
@@ -1248,7 +1260,7 @@ mod api {
   }
   #[test]
   fn set_3() -> Result<()> {
-    let mut tree = K2Tree::with_k(3)?;
+    let mut tree = K2Tree::with_k(3, 3)?;
     tree.grow();
     for i in 0..6561 {
       let [x, y] = [i%81, i/81];
@@ -1263,7 +1275,7 @@ mod api {
   fn matrix_width_and_grow_0() -> Result<()> {
     for k in 2..9usize {
       let k_cubed = k.pow(3);
-      let mut tree = K2Tree::with_k(k)?;
+      let mut tree = K2Tree::with_k(k, k)?;
       assert_eq!(k_cubed, tree.matrix_width);
       tree.grow();
       assert_eq!(k_cubed*k, tree.matrix_width);
@@ -1288,9 +1300,9 @@ mod api {
     Ok(())
   }
   #[test]
-  fn k() -> Result<()> {
+  fn stem_k() -> Result<()> {
     for k in 2..9 {
-      assert_eq!(k, K2Tree::with_k(k)?.k);
+      assert_eq!(k, K2Tree::with_k(k, k)?.stem_k);
     }
     Ok(())
   }
@@ -1470,7 +1482,7 @@ mod api {
   fn shrink_if_possible() -> Result<()> {
     for k in 2..9usize {
       let mw = k.pow(3);
-      let mut tree = K2Tree::with_k(k)?;
+      let mut tree = K2Tree::with_k(k, k)?;
       tree.grow();
       assert_eq!(mw*k, tree.matrix_width);
       tree.shrink_if_possible();
@@ -1484,7 +1496,7 @@ mod api {
   fn shrink() -> Result<()> {
     for k in 2..9usize {
       let mw = k.pow(3);
-      let mut tree = K2Tree::with_k(k)?;
+      let mut tree = K2Tree::with_k(k, k)?;
       tree.grow();
       assert_eq!(mw*k, tree.matrix_width);
       assert!(tree.shrink().is_ok());
@@ -1497,7 +1509,7 @@ mod api {
   #[test]
   fn shrink_unchecked() -> Result<()> {
     for k in 2..9usize {
-      let mut tree = K2Tree::with_k(k)?;
+      let mut tree = K2Tree::with_k(k, k)?;
       tree.grow();
       assert_eq!(k.pow(4), tree.matrix_width);
       unsafe { tree.shrink_unchecked(); }
@@ -1604,14 +1616,14 @@ mod util {
     assert_eq!(tree.layer_len(1), 112);
   }
   #[test]
-  fn leaf_start_0() {
+  fn stem_to_leaf_start_0() {
     let tree = K2Tree::test_tree(2);
-    assert_eq!(tree.leaf_start(4), Ok(0));
-    assert_eq!(tree.leaf_start(5), Ok(4));
-    assert_eq!(tree.leaf_start(7), Ok(8));
-    assert_eq!(tree.leaf_start(8), Ok(12));
-    assert_eq!(tree.leaf_start(12), Ok(16));
-    assert_eq!(tree.leaf_start(9), Err(()));
+    assert_eq!(tree.stem_to_leaf_start(4), Ok(0));
+    assert_eq!(tree.stem_to_leaf_start(5), Ok(4));
+    assert_eq!(tree.stem_to_leaf_start(7), Ok(8));
+    assert_eq!(tree.stem_to_leaf_start(8), Ok(12));
+    assert_eq!(tree.stem_to_leaf_start(12), Ok(16));
+    assert_eq!(tree.stem_to_leaf_start(9), Err(()));
   }
   #[test]
   fn child_stem_0() {
@@ -1650,7 +1662,7 @@ mod misc {
   fn flood() -> Result<()> {
     use rand::Rng;
     let mut rng = rand::thread_rng();
-    let mut tree = K2Tree::with_k(2)?;
+    let mut tree = K2Tree::with_k(2, 2)?;
     for _ in 0..10 { tree.grow(); }
     for _ in 0..500 {
       let x: usize = rng.gen_range(0, 512);

--- a/src/tree/datastore.rs
+++ b/src/tree/datastore.rs
@@ -1796,7 +1796,7 @@ mod misc {
 mod many_k {
   use super::*;
   #[test]
-  fn build_0() -> Result<()> {
+  fn build() -> Result<()> {
     for i in 2..=3 {
       for stem_k in 2..9 {
         for leaf_k in 2..9 {

--- a/src/tree/datastore.rs
+++ b/src/tree/datastore.rs
@@ -392,11 +392,11 @@ impl K2Tree {
           && all_zeroes(&self.stems, stem_start, stem_start+stem_len) {
             if curr_layer == self.max_slayers-1 {
               for stem_to_leaf_bit in &mut self.stem_to_leaf[leaf_start/leaf_len..] {
-                *stem_to_leaf_bit -= stem_len; //TODO: check
+                *stem_to_leaf_bit -= stem_len;
               }
             }
             for layer_start in &mut self.slayer_starts[curr_layer+1..] {
-              // NOTE: this was 1 but it looks like that was an uncaught error, changed to stem__len
+              // NOTE: this was 1 but it looks like that was an uncaught error, changed to stem_len
               //       if any errors, look here.
               *layer_start -= stem_len; //Adjust lower layer start positions to reflect removal of stem
             }
@@ -612,7 +612,8 @@ impl K2Tree {
   /// fn main() -> Result<(), k2_tree::error::K2TreeError> {
   ///   use k2_tree::K2Tree;
   ///   let mut tree = K2Tree::with_k(2, 2)?;
-  ///   assert_eq!(2, tree.stem_k); //TODO
+  ///   assert_eq!(2, tree.stem_k);
+  ///   assert_eq!(2, tree.leaf_k);
   ///   assert_eq!(8, tree.matrix_width);
   ///   tree.grow();
   ///   assert_eq!(16, tree.matrix_width);
@@ -883,9 +884,17 @@ struct DescendEnv {
   slayer_max: usize,
 }
 impl K2Tree {
-  fn layer_from_range(&self, r: Range2D) -> usize { //TODO: Check stem_k cool
-    ((self.matrix_width as f64).log(self.stem_k as f64) as usize)
-    - ((r.width() as f64).log(self.stem_k as f64) as usize)
+  fn layer_from_range(&self, r: Range2D) -> usize {
+    (self.max_slayers+1) -
+    (
+      ((r.width()/self.leaf_k) as f64).log(self.stem_k as f64) as usize
+      +1
+    )
+    /*
+    Save for now, just in-case my maths for the multiple-ks is wrong
+      ((self.matrix_width as f64).log(self.k as f64) as usize)
+      - ((r.width() as f64).log(self.k as f64) as usize)
+    */
   }
   fn matrix_bit(&self, x: usize, y: usize, m_width: usize) -> Result<DescendResult> {
     let env = DescendEnv {

--- a/src/tree/datastore.rs
+++ b/src/tree/datastore.rs
@@ -65,7 +65,8 @@ impl K2Tree {
   /// let tree = K2Tree::new();
   /// assert!(tree.is_empty());
   /// assert_eq!(8, tree.matrix_width);
-  /// assert_eq!(2, tree.stem_k); //TODO
+  /// assert_eq!(2, tree.stem_k);
+  /// assert_eq!(2, tree.leaf_k);
   /// ```
   pub fn new() -> Self {
     K2Tree {
@@ -89,13 +90,17 @@ impl K2Tree {
   ///   assert!(tree.is_empty());
   ///   assert_eq!(4usize.pow(3), tree.matrix_width);
   ///   assert_eq!(64, tree.matrix_width);
-  ///   assert_eq!(4, tree.stem_k); //TODO
+  ///   assert_eq!(4, tree.stem_k);
+  ///   assert_eq!(4, tree.leaf_k);
   ///   Ok(())
   /// }
   /// ``` 
   pub fn with_k(stem_k: usize, leaf_k: usize) -> Result<Self> {
-    if stem_k < 2 || leaf_k < 2 {
-      return Err(Error::SmallKValue { k: stem_k as u8 }) //TODO: proper error
+    if stem_k < 2 {
+      return Err(Error::SmallStemKValue { stem_k: stem_k as u8 })
+    }
+    else if leaf_k < 2 {
+      return Err(Error::SmallLeafKValue { leaf_k: leaf_k as u8 })
     }
     /* For now fix k as 2, further work to make it user-defined */
     let mw = leaf_k * stem_k.pow(2);
@@ -125,7 +130,7 @@ impl K2Tree {
   pub fn set_stem_k(&mut self, stem_k: usize) -> Result<()> {
     if self.stem_k == stem_k { return Ok(()) }
     if stem_k < 2 {
-      return Err(Error::SmallKValue{k: stem_k as u8})
+      return Err(Error::SmallStemKValue{stem_k: stem_k as u8})
     }
     *self = K2Tree::from_matrix(self.to_matrix()?, stem_k, self.leaf_k)?;
     Ok(())
@@ -145,7 +150,7 @@ impl K2Tree {
   pub fn set_leaf_k(&mut self, leaf_k: usize) -> Result<()> {
     if self.leaf_k == leaf_k { return Ok(()) }
     if leaf_k < 2 {
-      return Err(Error::SmallKValue{k: leaf_k as u8})
+      return Err(Error::SmallLeafKValue{leaf_k: leaf_k as u8})
     }
     *self = K2Tree::from_matrix(self.to_matrix()?, self.stem_k, leaf_k)?;
     Ok(())

--- a/src/tree/datastore.rs
+++ b/src/tree/datastore.rs
@@ -539,10 +539,9 @@ impl K2Tree {
               AND update offsets greater than the block_start of the new stem.
           */
           let block_start = (layer_bit_pos / stem_len) * stem_len;
-          self.stem_to_leaf = self.stem_to_leaf.iter().map(
-            |&n|
-              if n >= block_start { n + stem_len }
-              else { n }
+          self.stem_to_leaf = self.stem_to_leaf.iter().map(|&n|
+            if n >= block_start { n + stem_len }
+            else { n }
           ).collect();
         }
         let mut stem_to_leaf_pos: usize = 0;
@@ -745,9 +744,10 @@ impl K2Tree {
   /// ```
   pub fn into_matrix(self) -> Result<BitMatrix> {
     let mut m = BitMatrix::with_dimensions(self.matrix_width, self.matrix_width);
-    for y in 0..self.matrix_width {
-      for x in 0..self.matrix_width {
-        if let Err(e) = m.set(x, y, self.get(x, y)?) {
+    for (pos, &state) in self.leaves.iter().enumerate() {
+      if state {
+        let [x, y] = self.get_coords(pos);
+        if let Err(e) = m.set(x, y, true) {
           return Err(Error::BitMatrixError {
             source: Box::new(e),
           })
@@ -774,11 +774,12 @@ impl K2Tree {
   ///   Ok(())
   /// }
   /// ```
-  pub fn to_matrix(&self) -> Result<BitMatrix> { //TODO: too expensive, try use get_coords
+  pub fn to_matrix(&self) -> Result<BitMatrix> {
     let mut m = BitMatrix::with_dimensions(self.matrix_width, self.matrix_width);
-    for y in 0..self.matrix_width {
-      for x in 0..self.matrix_width {
-        if let Err(e) = m.set(x, y, self.get(x, y)?) {
+    for (pos, &state) in self.leaves.iter().enumerate() {
+      if state {
+        let [x, y] = self.get_coords(pos);
+        if let Err(e) = m.set(x, y, true) {
           return Err(Error::BitMatrixError {
             source: Box::new(e),
           })

--- a/src/tree/datastore.rs
+++ b/src/tree/datastore.rs
@@ -774,7 +774,7 @@ impl K2Tree {
   ///   Ok(())
   /// }
   /// ```
-  pub fn to_matrix(&self) -> Result<BitMatrix> { //TODO: too expensive
+  pub fn to_matrix(&self) -> Result<BitMatrix> { //TODO: too expensive, try use get_coords
     let mut m = BitMatrix::with_dimensions(self.matrix_width, self.matrix_width);
     for y in 0..self.matrix_width {
       for x in 0..self.matrix_width {

--- a/src/tree/datastore.rs
+++ b/src/tree/datastore.rs
@@ -1187,6 +1187,61 @@ mod api {
     assert_eq!(tree, expected);
   }
   #[test]
+  fn set_leaf_k_0() {
+    let mut tree = K2Tree::new();
+    for valid_k in 2..7 {
+      assert!(tree.set_leaf_k(valid_k).is_ok());
+    }
+    for invalid_k in 0..2 {
+      assert!(tree.set_leaf_k(invalid_k).is_err());
+    }
+  }
+  #[test]
+  fn set_leaf_k_1() {
+    let mut tree = K2Tree::test_tree(2);
+    assert!(tree.set_leaf_k(3).is_ok());
+    let expected = K2Tree {
+      matrix_width: 12,
+      stem_k: 2,
+      leaf_k: 3,
+      max_slayers: 2,
+      slayer_starts: vec![0, 4],
+      stems: bitvec![
+        1,1,0,0, 0,1,1,1, 1,0,0,0,
+      ],
+      stem_to_leaf: vec![1,2,3,4],
+      leaves: bitvec![
+        0,0,1,0,1,0,0,0,0, 0,0,0,1,0,0,0,0,0,
+        0,0,0,0,0,1,0,1,0, 0,1,0,0,1,0,1,1,0
+      ],
+    };
+    assert_eq!(tree, expected);
+  }
+  #[test]
+  fn set_leaf_k_2() {
+    let mut tree = K2Tree::test_tree(3);
+    assert!(tree.set_leaf_k(2).is_ok());
+    let expected = K2Tree {
+      matrix_width: 54,
+      stem_k: 3,
+      leaf_k: 2,
+      max_slayers: 3,
+      slayer_starts: vec![0, 9, 27],
+      stems: bitvec![
+        1,0,0,1,0,0,0,0,0, 0,1,1,1,1,0,0,0,0, 1,1,0,0,0,0,0,0,0, //final layer starts below
+        0,1,1,0,0,1,0,0,0, 1,0,0,1,0,0,0,0,0, 0,0,0,1,0,0,0,0,0,
+        0,0,0,0,0,1,0,1,0, 1,0,0,0,0,0,0,0,0, 0,1,1,0,0,0,0,0,0
+      ],
+      stem_to_leaf: vec![1,2,5,9,12,21,32,34,36,45,46],
+      leaves: bitvec![
+        0,0,0,1, 1,0,0,0, 0,1,0,0, 1,0,1,0, 1,0,0,0,
+        0,0,1,0, 0,0,1,0, 0,1,0,0, 1,0,0,0, 0,0,0,1,
+        1,0,0,0
+      ],
+    };
+    assert_eq!(tree, expected);
+  }
+  #[test]
   fn is_empty_0() -> Result<()> {
     for stem_k in 2..10 {
       for leaf_k in 2..10 {

--- a/src/tree/iterators.rs
+++ b/src/tree/iterators.rs
@@ -49,7 +49,7 @@ pub struct Stems<'a> {
 impl<'a> Iterator for Stems<'a> {
   type Item = StemBit;
   fn next(&mut self) -> Option<Self::Item> {
-    let block_len = self.tree.block_len();
+    let block_len = self.tree.stem_len();  //TODO: check
     if self.pos >= self.tree.stems.len() {
       return None
     }
@@ -103,7 +103,7 @@ pub struct IntoStems {
 impl Iterator for IntoStems {
   type Item = StemBit;
   fn next(&mut self) -> Option<Self::Item> {
-    let block_len = self.tree.block_len();
+    let block_len = self.tree.stem_len(); //TODO
     if self.pos >= self.tree.stems.len() {
       return None
     }
@@ -157,8 +157,8 @@ impl<'a> Iterator for Leaves<'a> {
     if self.pos == self.tree.leaves.len() { return None }
     let [x, y] = self.tree.get_coords(self.pos);
     let value = self.tree.leaves[self.pos];
-    let leaf = self.pos / self.tree.block_len();
-    let bit = self.pos % self.tree.block_len();
+    let leaf = self.pos / self.tree.leaf_len();
+    let bit = self.pos % self.tree.leaf_len();
     self.pos += 1;
     Some(LeafBit {
       value,
@@ -191,8 +191,8 @@ impl Iterator for IntoLeaves {
     if self.pos == self.tree.leaves.len() { return None }
     let [x, y] = self.tree.get_coords(self.pos);
     let value = self.tree.leaves[self.pos];
-    let leaf = self.pos / self.tree.block_len();
-    let bit = self.pos % self.tree.block_len();
+    let leaf = self.pos / self.tree.leaf_len(); //TODO: check
+    let bit = self.pos % self.tree.leaf_len();
     self.pos += 1;
     Some(LeafBit {
       value,

--- a/src/tree/iterators.rs
+++ b/src/tree/iterators.rs
@@ -49,7 +49,7 @@ pub struct Stems<'a> {
 impl<'a> Iterator for Stems<'a> {
   type Item = StemBit;
   fn next(&mut self) -> Option<Self::Item> {
-    let block_len = self.tree.stem_len();  //TODO: check
+    let stem_len = self.tree.stem_len();
     if self.pos >= self.tree.stems.len() {
       return None
     }
@@ -62,9 +62,9 @@ impl<'a> Iterator for Stems<'a> {
     });
     /* Increment the iterator's state for next value */
     self.pos += 1;
-    if self.bit == block_len-1 {
+    if self.bit == stem_len-1 {
       self.bit = 0;
-      if self.stem == (self.tree.layer_len(self.layer) / block_len) - 1 {
+      if self.stem == (self.tree.layer_len(self.layer) / stem_len) - 1 {
         self.stem = 0;
         self.layer += 1;
       }
@@ -103,7 +103,7 @@ pub struct IntoStems {
 impl Iterator for IntoStems {
   type Item = StemBit;
   fn next(&mut self) -> Option<Self::Item> {
-    let block_len = self.tree.stem_len(); //TODO
+    let stem_len = self.tree.stem_len();
     if self.pos >= self.tree.stems.len() {
       return None
     }
@@ -116,9 +116,9 @@ impl Iterator for IntoStems {
     });
     /* Increment the iterator's state for next value */
     self.pos += 1;
-    if self.bit == block_len-1 {
+    if self.bit == stem_len-1 {
       self.bit = 0;
-      if self.stem == (self.tree.layer_len(self.layer) / block_len) - 1 {
+      if self.stem == (self.tree.layer_len(self.layer) / stem_len) - 1 {
         self.stem = 0;
         self.layer += 1;
       }
@@ -189,10 +189,11 @@ impl Iterator for IntoLeaves {
   type Item = LeafBit;
   fn next(&mut self) -> Option<Self::Item> {
     if self.pos == self.tree.leaves.len() { return None }
+    let leaf_len = self.tree.leaf_len();
     let [x, y] = self.tree.get_coords(self.pos);
     let value = self.tree.leaves[self.pos];
-    let leaf = self.pos / self.tree.leaf_len(); //TODO: check
-    let bit = self.pos % self.tree.leaf_len();
+    let leaf = self.pos / leaf_len;
+    let bit = self.pos % leaf_len;
     self.pos += 1;
     Some(LeafBit {
       value,

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -53,7 +53,7 @@ impl K2Tree {
   fn leaf_parent(&self, bit_pos: usize) -> usize {
     self.layer_start(self.max_slayers-1) + self.stem_to_leaf[bit_pos / self.leaf_len()]
   }
-  fn parent(&self, stem_start: usize) -> std::result::Result<[usize; 2], ()> { //TODO: test
+  fn parent(&self, stem_start: usize) -> std::result::Result<[usize; 2], ()> {
     /* Returns [stem_start, bit_offset] */
     if stem_start < self.slayer_starts[1] {
       return Err(())

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -46,7 +46,6 @@ impl K2Tree {
     // let mut range = [[0, self.matrix_width-1], [0, self.matrix_width-1]];
     for child_offset in offsets.into_iter().take(self.max_slayers) {
       range = self.to_subranges(range).unwrap()[child_offset];
-      // range = to_4_subranges(range)[child_offset];
     }
     let leaf_offset = leaf_bit_pos - self.leaf_start(leaf_bit_pos);
     let x = leaf_offset % self.leaf_k; //TODO: check

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -24,16 +24,15 @@ impl K2Tree {
     }
     self.slayer_starts[l+1] - self.slayer_starts[l]
   }
-  fn get_coords(&self, leaf_bit_pos: usize) -> [usize; 2] { //TODO: Verify
+  fn get_coords(&self, leaf_bit_pos: usize) -> [usize; 2] {
     /* Start at the leaf_bit and traverse our way up to the top of the tree,
     keeping track of the path we took on our way up in terms of
     bit-positions (offsets) in the stems. Then, traverse back down the same
     path to find the coords of the leaf_bit. */
     let parent_bit = self.leaf_parent(leaf_bit_pos);
-    let mut stem_start = self.stem_start(parent_bit); //TODO: check
+    let mut stem_start = self.stem_start(parent_bit);
     let mut offset = parent_bit - stem_start;
-    let mut offsets = Vec::new();
-    offsets.push(offset);
+    let mut offsets = vec![offset];
     for _ in 1..self.max_slayers {
       let parent = self.parent(stem_start).unwrap();
       stem_start = parent[0];
@@ -43,48 +42,40 @@ impl K2Tree {
     /* Reverse the offsets ready to traverse them back down the tree */
     offsets.reverse();
     let mut range = Range2D::new(0, self.matrix_width-1, 0, self.matrix_width-1);
-    // let mut range = [[0, self.matrix_width-1], [0, self.matrix_width-1]];
     for child_offset in offsets.into_iter().take(self.max_slayers) {
       range = self.to_subranges(range).unwrap()[child_offset];
     }
     let leaf_offset = leaf_bit_pos - self.leaf_start(leaf_bit_pos);
-    let x = leaf_offset % self.leaf_k; //TODO: check
-    let y = leaf_offset / self.leaf_k;  //TODO: check
-    [range.min_x + x, range.min_y + y] //TODO: Verify
-    // match leaf_offset {
-    //   0 => [range[0][0], range[1][0]],
-    //   1 => [range[0][1], range[1][0]],
-    //   2 => [range[0][0], range[1][1]],
-    //   3 => [range[0][1], range[1][1]],
-    //   _ => unreachable!(),
-    // }
+    let x = leaf_offset % self.leaf_k;
+    let y = leaf_offset / self.leaf_k;
+    [range.min_x + x, range.min_y + y]
   }
   fn leaf_parent(&self, bit_pos: usize) -> usize {
-    self.layer_start(self.max_slayers-1) + self.stem_to_leaf[bit_pos / self.leaf_len()] //TODO: check
+    self.layer_start(self.max_slayers-1) + self.stem_to_leaf[bit_pos / self.leaf_len()]
   }
-  fn parent(&self, stem_start: usize) -> std::result::Result<[usize; 2], ()> { //TODO
-    /* Returns (stem_start, bit_offset) */
+  fn parent(&self, stem_start: usize) -> std::result::Result<[usize; 2], ()> { //TODO: test
+    /* Returns [stem_start, bit_offset] */
     if stem_start < self.slayer_starts[1] {
       return Err(())
     }
-    let block_len = self.stem_len(); //TODO: check
+    let stem_len = self.stem_len();
     /* Find which layer stem_start is in */
     let stem_layer = {
       let mut layer = self.max_slayers-1; //If no match, must be in highest layer
       for (i, &layer_start) in self.slayer_starts.iter().enumerate() {
-        if stem_start <= layer_start { layer = i; break }
+        if stem_start < layer_start { layer = i-1; break }
       }
       layer
     };
     /* Find the nth stem it is in the layer */
-    let stem_num = (stem_start - stem_layer) / block_len;
+    let stem_num = (stem_start - self.slayer_starts[stem_layer]) / stem_len;
     /* Find the nth 1 in the parent layer */
     let parent_bit = one_positions_range(
       &self.stems,
       self.slayer_starts[stem_layer-1],
       self.slayer_starts[stem_layer]
     )[stem_num];
-    Ok([self.stem_start(parent_bit), parent_bit % block_len])
+    Ok([self.stem_start(parent_bit), parent_bit % stem_len])
   }
   fn layer_start(&self, l: usize) -> usize {
     if l == self.slayer_starts.len() {
@@ -111,7 +102,7 @@ impl K2Tree {
     (bit_pos / self.leaf_len()) * self.leaf_len()
   }
   fn to_subranges(&self, r: Range2D) -> std::result::Result<SubRanges, crate::error::SubRangesError> {
-    SubRanges::from_range(r, self.stem_k, self.stem_k) //TODO: check
+    SubRanges::from_range(r, self.stem_k, self.stem_k)
   }
 }
 


### PR DESCRIPTION
This was done to allow users more freedom when adjusting their parameters, which can provide higher rates of compression depending on the characteristics of a bit-matrix. For more information, see the paper linked in the readme.