### PR TITLE
No stem to leaf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k2_tree"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["GGabi <gabrielroels@googlemail.com>"]
 readme = "README.md"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ K2Tree {
   leaf_k: 2,
   max_slayers: 2,
   slayer_starts: [0, 4],
-  stems: [0111110111000100],
+  stems: [0111 1101 1100 0100],
   stem_to_leaf: [0, 1, 3, 4, 5, 9],
   leaves: [100010110010101010001100],
 }
@@ -56,7 +56,7 @@ For a more in-depth explenation of the explanation process, [check this out](HOW
 # The Road to 1.0:
 - [x] Make `K2Tree` work over any value of K.
 - [x]  Separate the `k` field into two distinct fields: `stem_k`, `leaf_k`.
-- [ ]  Attempt to increase compression ratio by removing the `stem_to_leaf` field without compromising operation complexity.
+- [x]  Attempt to increase compression ratio by removing the `stem_to_leaf` field without compromising operation complexity.
 - [ ] Unit test all the things.
 - [ ] Stabilise the API.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See the original proposal [here](https://users.dcc.uchile.cl/~gnavarro/ps/spire0
 Add  `k2_tree`  into your project dependencies:
 ```none
 [dependencies]
-k2_tree = "0.4.0"
+k2_tree = "0.4.1"
 ```
 # When `K2Tree`s are Useful:
 `K2Tree`s are extremely efficient at representing data that can be encoded as a two-dimensional bit-matrix, especially if said matrix is sparsely populated.
@@ -48,7 +48,6 @@ K2Tree {
   max_slayers: 2,
   slayer_starts: [0, 4],
   stems: [0111 1101 1100 0100],
-  stem_to_leaf: [0, 1, 3, 4, 5, 9],
   leaves: [100010110010101010001100],
 }
 ```
@@ -56,7 +55,7 @@ For a more in-depth explenation of the explanation process, [check this out](HOW
 # The Road to 1.0:
 - [x] Make `K2Tree` work over any value of K.
 - [x]  Separate the `k` field into two distinct fields: `stem_k`, `leaf_k`.
-- [x]  Attempt to increase compression ratio by removing the `stem_to_leaf` field without compromising operation complexity.
+- [x]  Increase compression ratio by removing the `stem_to_leaf` field without compromising operation complexity.
 - [ ] Unit test all the things.
 - [ ] Stabilise the API.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ K2Tree {
   leaf_k: 2,
   max_slayers: 2,
   slayer_starts: [0, 4],
-  stems: [0111 1101 1100 0100],
+  stems: [0111110111000100],
   leaves: [100010110010101010001100],
 }
 ```

--- a/src/tree/datastore.rs
+++ b/src/tree/datastore.rs
@@ -1033,8 +1033,8 @@ impl K2Tree {
   fn footprint(&self) -> usize {
     let mut size: usize = std::mem::size_of_val(self);
     size += std::mem::size_of::<usize>() * self.slayer_starts.len();
-    size += self.stems.len() / 8;
-    size += self.leaves.len() / 8;
+    size += self.stems.len() / std::mem::size_of::<u8>();
+    size += self.leaves.len() / std::mem::size_of::<u8>();
     size
   }
   #[allow(dead_code)]
@@ -1759,6 +1759,31 @@ mod many_k {
         }
       }
     }
+    Ok(())
+  }
+}
+
+#[cfg(test)]
+mod size_bench {
+  use super::*;
+  #[test]
+  fn matrix_vs_tree() -> Result<()> {
+    let matrices = [
+      K2Tree::test_matrix(2),
+      K2Tree::test_matrix(3),
+    ];
+    let trees = [
+      K2Tree::test_tree(2),
+      K2Tree::test_tree(3),
+      K2Tree::test_tree(4),
+    ];
+    let matrix_size = |m: &BitMatrix| {
+      return m.width * m.height / 8;
+    };
+    dbg!(&trees[1]);
+    dbg!(matrix_size(&matrices[0]), trees[0].footprint());
+    dbg!(matrix_size(&matrices[1]), trees[0].footprint());
+    dbg!(matrix_size(&trees[2].to_matrix()?), trees[2].footprint());
     Ok(())
   }
 }

--- a/src/tree/datastore.rs
+++ b/src/tree/datastore.rs
@@ -847,11 +847,6 @@ impl K2Tree {
       ((r.width()/self.leaf_k) as f64).log(self.stem_k as f64) as usize
       +1
     )
-    /*
-    Save for now, just in-case my maths for the multiple-ks is wrong
-      ((self.matrix_width as f64).log(self.k as f64) as usize)
-      - ((r.width() as f64).log(self.k as f64) as usize)
-    */
   }
   fn matrix_bit(&self, x: usize, y: usize, m_width: usize) -> Result<DescendResult> {
     let env = DescendEnv {
@@ -1033,8 +1028,8 @@ impl K2Tree {
   fn footprint(&self) -> usize {
     let mut size: usize = std::mem::size_of_val(self);
     size += std::mem::size_of::<usize>() * self.slayer_starts.len();
-    size += self.stems.len() / std::mem::size_of::<u8>();
-    size += self.leaves.len() / std::mem::size_of::<u8>();
+    size += self.stems.len() / 8;
+    size += self.leaves.len() / 8;
     size
   }
   #[allow(dead_code)]
@@ -1759,31 +1754,6 @@ mod many_k {
         }
       }
     }
-    Ok(())
-  }
-}
-
-#[cfg(test)]
-mod size_bench {
-  use super::*;
-  #[test]
-  fn matrix_vs_tree() -> Result<()> {
-    let matrices = [
-      K2Tree::test_matrix(2),
-      K2Tree::test_matrix(3),
-    ];
-    let trees = [
-      K2Tree::test_tree(2),
-      K2Tree::test_tree(3),
-      K2Tree::test_tree(4),
-    ];
-    let matrix_size = |m: &BitMatrix| {
-      return m.width * m.height / 8;
-    };
-    dbg!(&trees[1]);
-    dbg!(matrix_size(&matrices[0]), trees[0].footprint());
-    dbg!(matrix_size(&matrices[1]), trees[0].footprint());
-    dbg!(matrix_size(&trees[2].to_matrix()?), trees[2].footprint());
     Ok(())
   }
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -51,7 +51,13 @@ impl K2Tree {
     [range.min_x + x, range.min_y + y]
   }
   fn leaf_parent(&self, bit_pos: usize) -> usize {
-    self.layer_start(self.max_slayers-1) + self.stem_to_leaf[bit_pos / self.leaf_len()]
+    let nth_leaf = bit_pos / self.leaf_len();
+    let stem_ones_positions = one_positions_range(
+      &self.stems,
+      self.layer_start(self.max_slayers-1),
+      self.stems.len()
+    );
+    self.layer_start(self.max_slayers-1) + stem_ones_positions[nth_leaf] //TODO: check
   }
   fn parent(&self, stem_start: usize) -> std::result::Result<[usize; 2], ()> {
     /* Returns [stem_start, bit_offset] */


### PR DESCRIPTION
Removing the stem_to_leaf field from K2Tree struct in order to maximise the compression ratio of the structure. This field was the highest priority field to remove because it took up the most space by far, being a vector of usizes.