### PR TITLE
Removing `slayer_starts` field from K2Tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k2_tree"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["GGabi <gabrielroels@googlemail.com>"]
 readme = "README.md"
 edition = "2018"

--- a/HOWITWORKS.md
+++ b/HOWITWORKS.md
@@ -68,12 +68,10 @@ The above `K2Tree` is stored as a series of bits:
 Finally, the bit representation of the K2Tree is stored alongside various metadata; so that the original matrix can be recovered and to greatly optimise various operations.
 ```rust
 K2Tree {
-  matrix_width: 8,
-  k: 2,
+  stem_k: 2,
+  leaf_k: 2,
   max_slayers: 2,
-  slayer_starts: [0, 4],
   stems: [0111110111000100],
-  stem_to_leaf: [0, 1, 3, 4, 5, 9],
   leaves: [100010110010101010001100],
 }
 ```

--- a/README.md
+++ b/README.md
@@ -45,16 +45,15 @@ K2Tree {
   stem_k: 2,
   leaf_k: 2,
   max_slayers: 2,
-  slayer_starts: [0, 4],
   stems: [0111110111000100],
   leaves: [100010110010101010001100],
 }
 ```
-For a more in-depth explenation of the explanation process, [check this out](HOWITWORKS.md).
+For a more in-depth explanation of the compression process, [check this out](HOWITWORKS.md).
 # The Road to 1.0:
 - [x] Make `K2Tree` work over any value of K.
 - [x]  Separate the `k` field into two distinct fields: `stem_k`, `leaf_k`.
-- [x]  Increase compression ratio by removing the `stem_to_leaf` field without compromising operation complexity.
+- [x]  Increase compression ratio by removing the `stem_to_leaf` and `slayer_starts` field without compromising operation complexity.
 - [ ] Unit test all the things.
 - [ ] Stabilise the API.
 

--- a/src/tree/datastore.rs
+++ b/src/tree/datastore.rs
@@ -803,12 +803,13 @@ impl core::fmt::Display for K2Tree {
     if self.leaves.len() == 0 { return write!(f, "[0000]") }
     let mut s = String::new();
     let mut i: usize = 1;
+    let layer_starts = self.layer_starts();
     for layer_num in 0..self.max_slayers {
-      for bit_pos in self.layer_start(layer_num)..self.layer_start(layer_num+1) {
+      for bit_pos in layer_starts[layer_num]..layer_starts[layer_num+1] {
         if self.stems[bit_pos] { s.push('1'); }
         else { s.push('0'); }
         if i == self.stem_k*self.stem_k
-        && (bit_pos - self.layer_start(layer_num)) < self.layer_len(layer_num)-1 {
+        && (bit_pos - layer_starts[layer_num]) < self.layer_len(layer_num)-1 {
           s.push_str(", ");
           i = 1;
         } 
@@ -1773,5 +1774,42 @@ mod many_k {
       }
     }
     Ok(())
+  }
+}
+
+#[cfg(test)]
+mod layer_tests {
+  use super::*;
+  #[test]
+  fn layer_start_0() {
+    let trees = [
+      K2Tree::test_tree(2),
+      K2Tree::test_tree(3),
+      K2Tree::test_tree(4)
+    ];
+    let expecteds = [
+      [0, 4],
+      [0, 9],
+      [0, 16]
+    ];
+    for k in 0..trees.len() {
+      for layer in 0..expecteds[k].len() {
+        assert_eq!(expecteds[k][layer], trees[k].layer_start(layer));
+      }
+    }
+  }
+  #[test]
+  fn layer_start_1() {
+    let mut tree = K2Tree::test_tree(3);
+    for _ in 0..9 { tree.grow(); }
+    tree.set(67, 78, true);
+    tree.set(100, 100, true);
+    tree.set(33, 146, true);
+    tree.set(43, 146, true);
+    dbg!(&tree);
+    let expected = [0, 9, 18, 27, 36, 45, 54, 63, 72, 99, 135];
+    for layer in 0..tree.max_slayers {
+      assert_eq!(expected[layer], tree.layer_start(layer));
+    }
   }
 }

--- a/src/tree/datastore.rs
+++ b/src/tree/datastore.rs
@@ -7,18 +7,6 @@ use {
 
 type Result<T> = std::result::Result<T, Error>;
 
-/*
-  Funcs which use slayer_starts:
-  - set()
-  - grow()
-  - shrink()
-  - Trait Display
-  - stem_to_leaf_start()
-
-  Instances used in hot code:
-  - None?
-*/
-
 /// A collection designed to efficiently compress sparsely-populated bit-matrices.
 ///
 /// The `K2Tree` represents a matrix of bits and behaves ***as if*** it is a bit-matrix.
@@ -47,9 +35,7 @@ pub struct K2Tree {
   /// The k value of the K2Tree's leaves.
   pub leaf_k: usize,
   /// The maximum number of stem-layers possible given the matrix_width.
-  pub max_slayers: usize, //Could I encode this in the length of slayer_starts? Without making code much slower?
-  /// The index of the first bit in each stem-layer in stems.
-  pub slayer_starts: Vec<usize>,
+  pub max_slayers: usize,
   /// The bits that comprise the stems of the tree. 
   pub stems: BitVec,
   /// The bits that comprise the leaves of the tree.
@@ -72,7 +58,6 @@ impl K2Tree {
       stem_k: 2,
       leaf_k: 2,
       max_slayers: 2,
-      slayer_starts: vec![0],
       stems: bitvec![0; 4],
       leaves: BitVec::new(),
     }
@@ -104,7 +89,6 @@ impl K2Tree {
       stem_k,
       leaf_k,
       max_slayers: 2,
-      slayer_starts: vec![0],
       stems: bitvec![0; stem_k*stem_k],
       leaves: BitVec::new(),
     })
@@ -151,7 +135,7 @@ impl K2Tree {
   }
   ///Returns true if a `K2Tree` contains no 1s.
   pub fn is_empty(&self) -> bool {
-    ones_in_range(&self.leaves, 0, self.leaves.len()) == 0
+    self.leaves.len() == 0
   }
   /// Returns that state of a bit at a specified coordinate in the bit-matrix the
   /// `K2Tree` represents.
@@ -377,7 +361,6 @@ impl K2Tree {
             /* If no more leaves, then remove all stems immediately
             and don't bother with complex stuff below */
             self.stems = bitvec![0; stem_len];
-            self.slayer_starts = vec![0]; //DEAD
             return Ok(())
           }
           self.stems.set(stem_bit_pos, false); //Dead leaf parent bit = 0
@@ -385,11 +368,6 @@ impl K2Tree {
           let mut stem_start = self.stem_start(stem_bit_pos);
           while curr_layer > 0
           && all_zeroes(&self.stems, stem_start, stem_start+stem_len) {
-            for layer_start in &mut self.slayer_starts[curr_layer+1..] { //DEAD
-              // NOTE: this was 1 but it looks like that was an uncaught error, changed to stem_len
-              //       if any errors, look here.
-              *layer_start -= stem_len; //Adjust lower layer start positions to reflect removal of stem
-            }
             let [parent_stem_start, bit_offset] = self.parent(stem_start).unwrap();
             if let Err(()) = remove_block(&mut self.stems, stem_start, stem_len) {
               return  Err(Error::CorruptedK2Tree {
@@ -415,9 +393,13 @@ impl K2Tree {
           - Construct needed stems until reach final layer
           - Construct leaf corresponding to range containing (x, y)
           - Set bit at (x, y) to 1 */
-        //Either 0 or == max_slayers?
-        //ALIVE
-        let mut layer_starts_len = self.slayer_starts.len(); //cannot replace with max_slayers bc might not be max?
+        let mut layer_starts_len = if self.is_empty() {
+          /* K2Tree either has 1 stem at layer 1 when empty
+          or the max possible layers when a leaf exists */
+            1
+          } else {
+            self.max_slayers
+        };
         let mut layer = self.layer_from_range(stem_range);
         let mut subranges: SubRanges;
         /* Create correct stems in layers on the way down to the final layer,
@@ -446,14 +428,13 @@ impl K2Tree {
           };
           /* Change bit containing (x, y) to 1 */
           self.stems.set(stem_start + child_pos, true);
-          /* If we're not at max possible layer, but at the lowest
+          /* If we're not at max possible layer,
           but at the lowest existing layer: Create new layer before
           adding new stem to it.
           Otherwise: Find the correct position to add the new stem
           in the child layer. */
           if layer == layer_starts_len-1 {
             stem_start = self.stems.len();
-            self.slayer_starts.push(stem_start); //ALIVE
             layer_starts_len += 1;
           }
           else {
@@ -478,12 +459,6 @@ impl K2Tree {
                 })
               })
             })
-          }
-          /* If there are layers after the one we just insert a stem
-          into: Increase the layer_starts to account for
-          the extra stem */
-          for layer_start in &mut self.slayer_starts[layer+1..] { //DEAD
-            *layer_start += stem_len;
           }
         }
         /* We're at the final stem layer */
@@ -609,14 +584,9 @@ impl K2Tree {
   pub fn grow(&mut self) {
     let stem_len = self.stem_len();
     self.max_slayers += 1;
-    if self.leaves.len() > 0  {
+    if !self.is_empty() {
       /* Only insert the extra layers etc. if the
       tree isn't all 0s */
-      for slayer_start in &mut self.slayer_starts { //DEAD
-        *slayer_start += stem_len;
-      }
-      self.slayer_starts.insert(0, 0); //DEAD
-      /* Insert 10...00 to beginning of stems */
       for _ in 0..stem_len-1 { self.stems.insert(0, false); }
       self.stems.insert(0, true);
     }
@@ -671,10 +641,6 @@ impl K2Tree {
       })
     }
     self.max_slayers -= 1;
-    self.slayer_starts.remove(0); //DEAD
-    for slayer_start in &mut self.slayer_starts { //DEAD
-      *slayer_start -= stem_len;
-    }
     /* Remove top layer stem */
     for _ in 0..stem_len { self.stems.remove(0); }
     Ok(())
@@ -699,10 +665,6 @@ impl K2Tree {
   pub unsafe fn shrink_unchecked(&mut self) {
     let stem_len = self.stem_len();
     self.max_slayers -= 1;
-    self.slayer_starts.remove(0); //DEAD
-    for slayer_start in &mut self.slayer_starts { //DEAD
-      *slayer_start -= stem_len;
-    }
     /* Remove top layer stem */
     for _ in 0..stem_len { self.stems.remove(0); }
   }
@@ -951,7 +913,6 @@ impl K2Tree {
         stem_k: 2,
         leaf_k: 2,
         max_slayers: 2,
-        slayer_starts: vec![0, 4],
         stems:  bitvec![0,1,1,1, 1,1,0,1, 1,0,0,0, 1,0,0,0],
         leaves: bitvec![0,1,1,0, 0,1,0,1, 1,1,0,0, 1,0,0,0, 0,1,1,0],
       },
@@ -959,7 +920,6 @@ impl K2Tree {
         stem_k: 3,
         leaf_k: 3,
         max_slayers: 2,
-        slayer_starts: vec![0, 9],
         stems:  bitvec![
           0,1,0,1,1,0,1,1,0, 1,1,0,0,0,0,0,0,0, 1,0,0,0,0,0,0,0,0,
           1,0,0,0,0,0,0,0,0, 1,0,0,0,0,0,0,0,0, 1,0,0,0,0,0,0,0,0
@@ -973,7 +933,6 @@ impl K2Tree {
         stem_k: 4,
         leaf_k: 4,
         max_slayers: 2,
-        slayer_starts: vec![0, 16],
         stems: bitvec![
           1,0,0,1,0,0,0,1,1,0,0,0,1,1,0,1, 1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,
           0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,
@@ -1053,7 +1012,6 @@ impl K2Tree {
   #[allow(dead_code)]
   fn footprint(&self) -> usize {
     let mut size: usize = std::mem::size_of_val(self);
-    size += std::mem::size_of::<usize>() * self.slayer_starts.len(); //DEAD
     size += self.stems.len() / 8;
     size += self.leaves.len() / 8;
     size
@@ -1075,7 +1033,6 @@ mod api {
       stem_k: 2,
       leaf_k: 2,
       max_slayers: 2,
-      slayer_starts: vec![0],
       stems: bitvec![0,0,0,0],
       leaves: bitvec![],
     };
@@ -1094,7 +1051,6 @@ mod api {
           stem_k,
           leaf_k,
           max_slayers: 2,
-          slayer_starts: vec![0],
           stems: bitvec![0; stem_k.pow(2)],
           leaves: BitVec::new(),
         };
@@ -1121,7 +1077,6 @@ mod api {
       stem_k: 3,
       leaf_k: 2,
       max_slayers: 2,
-      slayer_starts: vec![0, 9],
       stems: bitvec![
         1,1,0,0,0,0,0,0,0, 0,0,1,0,0,0,1,0,1,
         1,0,0,1,0,0,0,0,0
@@ -1141,7 +1096,6 @@ mod api {
       stem_k: 2,
       leaf_k: 3,
       max_slayers: 4,
-      slayer_starts: vec![0, 4, 12, 32],
       stems: bitvec![
         1,0,0,0, 1,1,1,0, 0,1,1,1, 1,0,0,0, 0,0,1,1, //final layer begins here
         0,1,0,0, 0,0,1,0, 0,0,0,1, 1,0,0,0, 1,0,0,0, 0,1,0,0
@@ -1172,7 +1126,6 @@ mod api {
       stem_k: 2,
       leaf_k: 3,
       max_slayers: 2,
-      slayer_starts: vec![0, 4],
       stems: bitvec![
         1,1,0,0, 0,1,1,1, 1,0,0,0,
       ],
@@ -1191,7 +1144,6 @@ mod api {
       stem_k: 3,
       leaf_k: 2,
       max_slayers: 3,
-      slayer_starts: vec![0, 9, 27],
       stems: bitvec![
         1,0,0,1,0,0,0,0,0, 0,1,1,1,1,0,0,0,0, 1,1,0,0,0,0,0,0,0, //final layer starts below
         0,1,1,0,0,1,0,0,0, 1,0,0,1,0,0,0,0,0, 0,0,0,1,0,0,0,0,0,
@@ -1721,6 +1673,39 @@ mod util {
     let tree = K2Tree::test_tree(2);
     assert_eq!(tree.get_coords(12), [0, 4]);
   }
+  #[test]
+  fn layer_start_0() {
+    let trees = [
+      K2Tree::test_tree(2),
+      K2Tree::test_tree(3),
+      K2Tree::test_tree(4)
+    ];
+    let expecteds = [
+      [0, 4],
+      [0, 9],
+      [0, 16]
+    ];
+    for k in 0..trees.len() {
+      for layer in 0..expecteds[k].len() {
+        assert_eq!(expecteds[k][layer], trees[k].layer_start(layer));
+      }
+    }
+  }
+  #[test]
+  fn layer_start_1() -> Result<()> {
+    let mut tree = K2Tree::test_tree(3);
+    for _ in 0..9 { tree.grow(); }
+    tree.set(67, 78, true)?;
+    tree.set(100, 100, true)?;
+    tree.set(33, 146, true)?;
+    tree.set(43, 146, true)?;
+    dbg!(&tree);
+    let expected = [0, 9, 18, 27, 36, 45, 54, 63, 72, 99, 135];
+    for layer in 0..tree.max_slayers {
+      assert_eq!(expected[layer], tree.layer_start(layer));
+    }
+    Ok(())
+  }
 }
 
 #[cfg(test)]
@@ -1753,6 +1738,22 @@ mod misc {
   fn display() {
     println!("{}", K2Tree::test_tree(3));
   }
+  #[test]
+  fn eq() -> Result<()> {
+    assert_eq!(K2Tree::new(), K2Tree::new());
+    assert_eq!(K2Tree::test_tree(2), K2Tree::test_tree(2));
+    assert_eq!(K2Tree::test_tree(3), K2Tree::test_tree(3));
+    assert_eq!(K2Tree::test_tree(4), K2Tree::test_tree(4));
+    for stem_k in 2..10 {
+      for leaf_k in 2..10 {
+        assert_eq!(
+          K2Tree::with_k(stem_k, leaf_k)?,
+          K2Tree::with_k(stem_k, leaf_k)?
+        );
+      }
+    }
+    Ok(())
+  }
 }
 
 #[cfg(test)]
@@ -1775,42 +1776,5 @@ mod many_k {
       }
     }
     Ok(())
-  }
-}
-
-#[cfg(test)]
-mod layer_tests {
-  use super::*;
-  #[test]
-  fn layer_start_0() {
-    let trees = [
-      K2Tree::test_tree(2),
-      K2Tree::test_tree(3),
-      K2Tree::test_tree(4)
-    ];
-    let expecteds = [
-      [0, 4],
-      [0, 9],
-      [0, 16]
-    ];
-    for k in 0..trees.len() {
-      for layer in 0..expecteds[k].len() {
-        assert_eq!(expecteds[k][layer], trees[k].layer_start(layer));
-      }
-    }
-  }
-  #[test]
-  fn layer_start_1() {
-    let mut tree = K2Tree::test_tree(3);
-    for _ in 0..9 { tree.grow(); }
-    tree.set(67, 78, true);
-    tree.set(100, 100, true);
-    tree.set(33, 146, true);
-    tree.set(43, 146, true);
-    dbg!(&tree);
-    let expected = [0, 9, 18, 27, 36, 45, 54, 63, 72, 99, 135];
-    for layer in 0..tree.max_slayers {
-      assert_eq!(expected[layer], tree.layer_start(layer));
-    }
   }
 }

--- a/src/tree/datastore.rs
+++ b/src/tree/datastore.rs
@@ -377,7 +377,7 @@ impl K2Tree {
             /* If no more leaves, then remove all stems immediately
             and don't bother with complex stuff below */
             self.stems = bitvec![0; stem_len];
-            self.slayer_starts = vec![0];
+            self.slayer_starts = vec![0]; //DEAD
             return Ok(())
           }
           self.stems.set(stem_bit_pos, false); //Dead leaf parent bit = 0
@@ -385,7 +385,7 @@ impl K2Tree {
           let mut stem_start = self.stem_start(stem_bit_pos);
           while curr_layer > 0
           && all_zeroes(&self.stems, stem_start, stem_start+stem_len) {
-            for layer_start in &mut self.slayer_starts[curr_layer+1..] {
+            for layer_start in &mut self.slayer_starts[curr_layer+1..] { //DEAD
               // NOTE: this was 1 but it looks like that was an uncaught error, changed to stem_len
               //       if any errors, look here.
               *layer_start -= stem_len; //Adjust lower layer start positions to reflect removal of stem
@@ -416,6 +416,7 @@ impl K2Tree {
           - Construct leaf corresponding to range containing (x, y)
           - Set bit at (x, y) to 1 */
         //Either 0 or == max_slayers?
+        //ALIVE
         let mut layer_starts_len = self.slayer_starts.len(); //cannot replace with max_slayers bc might not be max?
         let mut layer = self.layer_from_range(stem_range);
         let mut subranges: SubRanges;
@@ -452,7 +453,7 @@ impl K2Tree {
           in the child layer. */
           if layer == layer_starts_len-1 {
             stem_start = self.stems.len();
-            self.slayer_starts.push(stem_start);
+            self.slayer_starts.push(stem_start); //ALIVE
             layer_starts_len += 1;
           }
           else {
@@ -481,7 +482,7 @@ impl K2Tree {
           /* If there are layers after the one we just insert a stem
           into: Increase the layer_starts to account for
           the extra stem */
-          for layer_start in &mut self.slayer_starts[layer+1..] {
+          for layer_start in &mut self.slayer_starts[layer+1..] { //DEAD
             *layer_start += stem_len;
           }
         }
@@ -611,10 +612,10 @@ impl K2Tree {
     if self.leaves.len() > 0  {
       /* Only insert the extra layers etc. if the
       tree isn't all 0s */
-      for slayer_start in &mut self.slayer_starts {
+      for slayer_start in &mut self.slayer_starts { //DEAD
         *slayer_start += stem_len;
       }
-      self.slayer_starts.insert(0, 0);
+      self.slayer_starts.insert(0, 0); //DEAD
       /* Insert 10...00 to beginning of stems */
       for _ in 0..stem_len-1 { self.stems.insert(0, false); }
       self.stems.insert(0, true);
@@ -670,8 +671,8 @@ impl K2Tree {
       })
     }
     self.max_slayers -= 1;
-    self.slayer_starts.remove(0);
-    for slayer_start in &mut self.slayer_starts {
+    self.slayer_starts.remove(0); //DEAD
+    for slayer_start in &mut self.slayer_starts { //DEAD
       *slayer_start -= stem_len;
     }
     /* Remove top layer stem */
@@ -698,8 +699,8 @@ impl K2Tree {
   pub unsafe fn shrink_unchecked(&mut self) {
     let stem_len = self.stem_len();
     self.max_slayers -= 1;
-    self.slayer_starts.remove(0);
-    for slayer_start in &mut self.slayer_starts {
+    self.slayer_starts.remove(0); //DEAD
+    for slayer_start in &mut self.slayer_starts { //DEAD
       *slayer_start -= stem_len;
     }
     /* Remove top layer stem */
@@ -924,7 +925,7 @@ impl K2Tree {
     else {
       let nth_leaf = ones_in_range(
         &self.stems,
-        self.slayer_starts[self.max_slayers-1],
+        self.layer_start(self.max_slayers-1),
         stem_bitpos
       );
       Ok(nth_leaf * self.leaf_len())
@@ -1052,7 +1053,7 @@ impl K2Tree {
   #[allow(dead_code)]
   fn footprint(&self) -> usize {
     let mut size: usize = std::mem::size_of_val(self);
-    size += std::mem::size_of::<usize>() * self.slayer_starts.len();
+    size += std::mem::size_of::<usize>() * self.slayer_starts.len(); //DEAD
     size += self.stems.len() / 8;
     size += self.leaves.len() / 8;
     size

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -14,6 +14,13 @@ pub use iterators::{
   LeavesRaw,
 };
 
+/*
+  Funcs which use slayer_starts:
+  - self.layer_len()
+  - self.parent()
+  - self.layer_start()
+*/
+
 /* Common */
 use bitvec::vec::BitVec;
 

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -14,12 +14,6 @@ pub use iterators::{
   LeavesRaw,
 };
 
-/*
-  Funcs which use slayer_starts:
-  - self.layer_len()
-  - self.parent()
-*/
-
 /* Common */
 use bitvec::vec::BitVec;
 
@@ -272,65 +266,65 @@ impl Range2D {
     && y >= self.min_y && y <= self.max_y
   }
 }
+impl PartialEq for Range2D {
+  fn eq(&self, other: &Self) -> bool {
+    self.min_x == other.min_x
+    && self.max_x == other.max_x
+    && self.min_y == other.min_y
+    && self.max_y == other.max_y
+  }
+}
+impl Eq for Range2D {}
 
 /* Tests */
-
-
-// #[cfg(test)]
-// mod range_tests {
-//   use super::*;
-//   #[test]
-//   fn range2d_from_range() {
-//     let range = [[0, 7], [0, 7]];
-//     let expected = Range2D {
-//       min_x: 0,
-//       max_x: 7,
-//       min_y: 0,
-//       max_y: 7,
-//     };
-//     assert_eq!(expected, Range2D::from_range(range));
-//   }
-//   #[test]
-//   fn subranges_from_range2d_0() {
-//     let original = Range2D::new(0, 7, 0, 7);
-//     let expected_subs = [
-//       Range2D::new(0, 3, 0, 3),
-//       Range2D::new(4, 7, 0, 3),
-//       Range2D::new(0, 3, 4, 7),
-//       Range2D::new(4, 7, 4, 7),
-//     ];
-//     let subs = SubRange::from_range(original, 2, 2);
-//     for i in 0..4 { assert_eq!(expected_subs[i], subs[i]); }
-//   }
-//   #[test]
-//   fn subranges_from_range2d_1() {
-//     let original = Range2D::new(0, 8, 0, 8);
-//     let expected_subs = [
-//       Range2D::new(0, 2, 0, 2),
-//       Range2D::new(3, 5, 0, 2),
-//       Range2D::new(6, 8, 0, 2),
-//       Range2D::new(0, 2, 3, 5),
-//       Range2D::new(3, 5, 3, 5),
-//       Range2D::new(6, 8, 3, 5),
-//       Range2D::new(0, 2, 6, 8),
-//       Range2D::new(3, 5, 6, 8),
-//       Range2D::new(6, 8, 6, 8),
-//     ];
-//     let subs = SubRange::from_range(original, 3, 3);
-//     for i in 0..9 { assert_eq!(expected_subs[i], subs[i]); }
-//   }
-//   #[test]
-//   fn subranges_from_range2d_2() {
-//     let original = Range2D::new(0, 8, 0, 7);
-//     let expected_subs = [
-//       Range2D::new(0, 2, 0, 3),
-//       Range2D::new(3, 5, 0, 3),
-//       Range2D::new(6, 8, 0, 3),
-//       Range2D::new(0, 2, 4, 7),
-//       Range2D::new(3, 5, 4, 7),
-//       Range2D::new(6, 8, 4, 7),
-//     ];
-//     let subs = SubRange::from_range(original, 3, 2);
-//     for i in 0..6 { assert_eq!(expected_subs[i], subs[i]); }
-//   }
-// }
+#[cfg(test)]
+mod range_tests {
+  use super::*;
+  type Result<T> = std::result::Result<T, crate::error::SubRangesError>;
+  #[test]
+  fn subranges_from_range2d_0() -> Result<()> {
+    let original = Range2D::new(0, 7, 0, 7);
+    let expected_subs = [
+      Range2D::new(0, 3, 0, 3),
+      Range2D::new(4, 7, 0, 3),
+      Range2D::new(0, 3, 4, 7),
+      Range2D::new(4, 7, 4, 7),
+    ];
+    let subs = SubRanges::from_range(original, 2, 2)?;
+    for i in 0..4 { assert_eq!(expected_subs[i], subs[i]); }
+    Ok(())
+  }
+  #[test]
+  fn subranges_from_range2d_1() -> Result<()> {
+    let original = Range2D::new(0, 8, 0, 8);
+    let expected_subs = [
+      Range2D::new(0, 2, 0, 2),
+      Range2D::new(3, 5, 0, 2),
+      Range2D::new(6, 8, 0, 2),
+      Range2D::new(0, 2, 3, 5),
+      Range2D::new(3, 5, 3, 5),
+      Range2D::new(6, 8, 3, 5),
+      Range2D::new(0, 2, 6, 8),
+      Range2D::new(3, 5, 6, 8),
+      Range2D::new(6, 8, 6, 8),
+    ];
+    let subs = SubRanges::from_range(original, 3, 3)?;
+    for i in 0..9 { assert_eq!(expected_subs[i], subs[i]); }
+    Ok(())
+  }
+  #[test]
+  fn subranges_from_range2d_2() -> Result<()> {
+    let original = Range2D::new(0, 8, 0, 7);
+    let expected_subs = [
+      Range2D::new(0, 2, 0, 3),
+      Range2D::new(3, 5, 0, 3),
+      Range2D::new(6, 8, 0, 3),
+      Range2D::new(0, 2, 4, 7),
+      Range2D::new(3, 5, 4, 7),
+      Range2D::new(6, 8, 4, 7),
+    ];
+    let subs = SubRanges::from_range(original, 3, 2)?;
+    for i in 0..6 { assert_eq!(expected_subs[i], subs[i]); }
+    Ok(())
+  }
+}


### PR DESCRIPTION
This was done in order to reduce the size of instances of K2Tree, which is of great priority because this object exists to compress bit-matrices.
The increase of runtime-complexity stemming from computing this on-the-fly during operations has not been noticeable, but this has yet to be formally measured.